### PR TITLE
bugfix: return object as map value, instead of String.

### DIFF
--- a/src/main/java/com/miragesql/miragesql/SqlManagerImpl.java
+++ b/src/main/java/com/miragesql/miragesql/SqlManagerImpl.java
@@ -35,6 +35,7 @@ import com.miragesql.miragesql.type.IntegerPrimitiveValueType;
 import com.miragesql.miragesql.type.IntegerValueType;
 import com.miragesql.miragesql.type.LongPrimitiveValueType;
 import com.miragesql.miragesql.type.LongValueType;
+import com.miragesql.miragesql.type.ObjectValueType;
 import com.miragesql.miragesql.type.ShortPrimitiveValueType;
 import com.miragesql.miragesql.type.ShortValueType;
 import com.miragesql.miragesql.type.SqlDateValueType;
@@ -95,6 +96,7 @@ public class SqlManagerImpl implements SqlManager {
         addValueType(new EnumStringValueType());
         addValueType(new EnumOrdinalValueType());
         addValueType(new EnumOneBasedOrdinalValueType());
+        addValueType(new ObjectValueType());
 //		addValueType(new com.miragesql.miragesql.type.DefaultValueType());
 
         setDialect(dialect);

--- a/src/main/java/com/miragesql/miragesql/bean/MapBeanDescImpl.java
+++ b/src/main/java/com/miragesql/miragesql/bean/MapBeanDescImpl.java
@@ -36,7 +36,7 @@ public class MapBeanDescImpl implements BeanDesc {
     /**{@inheritDoc}*/
     public PropertyDesc getPropertyDesc(String name) {
         if(this.map == null){
-            return new MapPropertyDescImpl(name, "");
+            return new MapPropertyDescImpl(name, new Object());
         }
         return this.propertyMap.get(name);
     }

--- a/src/main/java/com/miragesql/miragesql/type/ObjectValueType.java
+++ b/src/main/java/com/miragesql/miragesql/type/ObjectValueType.java
@@ -1,0 +1,37 @@
+package com.miragesql.miragesql.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class ObjectValueType extends AbstractValueType<Object> {
+
+    public ObjectValueType() {
+        super(Object.class);
+    }
+
+    public Object get(Class<? extends Object> type, ResultSet rs, int columnIndex) throws SQLException {
+        return rs.getObject(columnIndex);
+    }
+
+    public Object get(Class<? extends Object> type, ResultSet rs, String columnName) throws SQLException {
+        return rs.getObject(columnName);
+    }
+
+    public void set(Class<? extends Object> type, PreparedStatement stmt, Object value, int index) throws SQLException {
+        if (value == null) {
+            setNull(type, stmt, index);
+        } else {
+            stmt.setObject(index, value);
+        }
+    }
+
+    public Object get(Class<? extends Object> type, CallableStatement cs, int index) throws SQLException {
+        return cs.getObject(index);
+    }
+
+    public Object get(Class<? extends Object> type, CallableStatement cs, String parameterName) throws SQLException {
+        return cs.getObject(parameterName);
+    }
+}

--- a/src/test/java/com/miragesql/miragesql/SqlManagerImplTest.java
+++ b/src/test/java/com/miragesql/miragesql/SqlManagerImplTest.java
@@ -37,7 +37,8 @@ public class SqlManagerImplTest extends AbstractDatabaseTest {
 
 		assertEquals("Mirage in Action", map.get("bookName"));
 		assertEquals("Naoki Takezoe", map.get("author"));
-		assertEquals("20", map.get("price"));
+		assertEquals(Integer.class, map.get("price").getClass());
+		assertEquals(20, map.get("price"));
 	}
 
 	public void testSelectIn() throws Exception {


### PR DESCRIPTION
currently, virtually always returns Map<String, String>, instead of Map<String, Object>.