### PR TITLE
Update dependencies and remove unused dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 
 
 dependencies {
-    compile 'org.javassist:javassist:3.22.0-GA'
+    compile 'org.javassist:javassist:3.24.0-GA'
     compile 'ognl:ognl:3.2.4'
     compile 'org.slf4j:slf4j-api:1.7.25'
 
@@ -33,8 +33,7 @@ dependencies {
     compileOnly 'javax.servlet:servlet-api:2.5'                          // provided
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'cglib:cglib:3.2.5'
-    testImplementation 'org.mockito:mockito-core:2.13.0'
+    testImplementation 'org.mockito:mockito-core:2.23.0'
     testImplementation 'org.apache.commons:commons-lang3:3.7'
     testImplementation 'com.h2database:h2:1.4.196'
     testImplementation 'org.hsqldb:hsqldb:2.4.0'


### PR DESCRIPTION

* update javassist that has support for JDK11
* update mockito
* mockito has no dependencies of cglib. Since 2.1.0, mockito uses byte buddy.